### PR TITLE
Remove enable/disable/redirect_uri from StoredState

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -3,7 +3,3 @@
 
 get-redirect-uri:
   description: Get the Kratos' client redirect_uri
-enable:
-  description: Enable the external provider
-disable:
-  description: Disable the external provider

--- a/config.yaml
+++ b/config.yaml
@@ -69,3 +69,7 @@ options:
     description: Space separated list of allowed scopes for the provider.
     type: string
     default: profile email address phone
+  enabled:
+    description: Controls whether the provider is enabled.
+    type: boolean
+    default: True

--- a/lib/charms/kratos_external_idp_integrator/v0/kratos_external_provider.py
+++ b/lib/charms/kratos_external_idp_integrator/v0/kratos_external_provider.py
@@ -518,10 +518,10 @@ class ExternalIdpProvider(Object):
         for relation in self._charm.model.relations[self._relation_name]:
             relation.data[self._charm.app].clear()
 
-    def get_redirect_uri(self, relation_id: Optional[int] = None) -> str:
+    def get_redirect_uri(self, relation_id: Optional[int] = None) -> Optional[str]:
         """Get the kratos client's redirect_uri."""
         if not self.model.unit.is_leader():
-            return
+            return None
 
         try:
             relation = self.model.get_relation(
@@ -531,14 +531,14 @@ class ExternalIdpProvider(Object):
             raise RuntimeError("More than one relations are defined. Please provide a relation_id")
 
         if not relation or not relation.app:
-            return
+            return None
 
         data = relation.data[relation.app]
         data = _load_data(data, REQUIRER_JSON_SCHEMA)
         providers = data["providers"]
 
         if len(providers) == 0:
-            return
+            return None
 
         return providers[0].get("redirect_uri")
 

--- a/lib/charms/kratos_external_idp_integrator/v0/kratos_external_provider.py
+++ b/lib/charms/kratos_external_idp_integrator/v0/kratos_external_provider.py
@@ -261,6 +261,7 @@ class BaseProviderConfigHandler:
 
     mandatory_fields = {"provider", "client_id", "secret_backend", "scope"}
     optional_fields = {"provider_id", "jsonnet_mapper"}
+    excluded_fields = {"enabled"}
     providers: List[str] = []
 
     @classmethod
@@ -288,7 +289,8 @@ class BaseProviderConfigHandler:
             )
 
         for key in config_keys:
-            logger.warn(f"Invalid config '{key}' for provider '{provider}' will be ignored")
+            if key not in cls.excluded_fields:
+                logger.warn(f"Invalid config '{key}' for provider '{provider}' will be ignored")
 
         return {key: value for key, value in config.items() if key not in config_keys}
 

--- a/lib/charms/kratos_external_idp_integrator/v0/kratos_external_provider.py
+++ b/lib/charms/kratos_external_idp_integrator/v0/kratos_external_provider.py
@@ -119,7 +119,7 @@ from ops.charm import (
     RelationJoinedEvent,
 )
 from ops.framework import EventBase, EventSource, Handle, Object, ObjectEvents
-from ops.model import Relation
+from ops.model import Relation, TooManyRelatedAppsError
 
 # The unique Charmhub library identifier, never change it
 LIBID = "33040051de7f43a8bb43349f2b037dfc"
@@ -519,6 +519,7 @@ class ExternalIdpProvider(Object):
             relation.data[self._charm.app].clear()
 
     def get_redirect_uri(self, relation_id: Optional[int] = None) -> str:
+        """Get the kratos client's redirect_uri."""
         if not self.model.unit.is_leader():
             return
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -10,7 +10,6 @@ from typing import Any
 from charms.kratos_external_idp_integrator.v0.kratos_external_provider import (
     ExternalIdpProvider,
     InvalidConfigError,
-    RedirectURIChangedEvent,
 )
 from ops.charm import ActionEvent, CharmBase, ConfigChangedEvent, EventBase
 from ops.framework import StoredState

--- a/src/charm.py
+++ b/src/charm.py
@@ -64,7 +64,7 @@ class KratosIdpIntegratorCharm(CharmBase):
         - If no relation exists, status is waiting
         - Else status is active
         """
-        if self._stored.invalid_config:
+        if self._stored.invalid_config is True:
             pass
         elif not self.external_idp_provider.is_ready():
             self.unit.status = BlockedStatus("Waiting for relation with Kratos")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -232,19 +232,17 @@ def test_disable(
     config: Dict,
     generic_databag: Dict,
     relation_data: Dict,
-    mock_event: MagicMock,
 ) -> None:
     harness.update_config(config)
     relation_id = harness.add_relation("kratos-external-idp", "kratos-app")
     harness.update_relation_data(relation_id, "kratos-app", relation_data)
-
-    harness.charm._disable(mock_event)
+    harness.update_config(dict(enabled=False, **config))
 
     app_data = harness.get_relation_data(relation_id, harness.charm.app)
     assert isinstance(harness.charm.unit.status, ActiveStatus)
     assert app_data == {}
 
-    harness.charm._enable(mock_event)
+    harness.update_config(dict(enabled=True, **config))
 
     assert isinstance(harness.charm.unit.status, ActiveStatus)
     assert parse_databag(app_data) == generic_databag

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -219,8 +219,36 @@ def test_get_redirect_uri(
     assert mock_event.set_results.mock_calls[0].args == ({"redirect-uri": redirect_uri},)
 
 
-def test_get_no_redirect_uri(harness: Harness, config: Dict, mock_event: MagicMock) -> None:
+def test_get_redirect_uri_without_relation(
+    harness: Harness, config: Dict, mock_event: MagicMock
+) -> None:
     harness.update_config(config)
+
+    harness.charm._get_redirect_uri(mock_event)
+
+    mock_event.fail.assert_called_once_with("No redirect_uri found")
+
+
+def test_get_redirect_uri_without_relation_data(
+    harness: Harness, config: Dict, mock_event: MagicMock
+) -> None:
+    harness.update_config(config)
+    harness.add_relation("kratos-external-idp", "kratos-app")
+
+    harness.charm._get_redirect_uri(mock_event)
+
+    mock_event.fail.assert_called_once_with("No redirect_uri found")
+
+
+def test_get_redirect_uri_without_leadership(
+    harness: Harness, config: Dict, mock_event: MagicMock, relation_data: Dict
+) -> None:
+    harness.set_leader(False)
+    harness.update_config(config)
+
+    harness.update_config(config)
+    relation_id = harness.add_relation("kratos-external-idp", "kratos-app")
+    harness.update_relation_data(relation_id, "kratos-app", relation_data)
 
     harness.charm._get_redirect_uri(mock_event)
 


### PR DESCRIPTION
Using the stored state to set the charm's status was not a very good idea.

- Remove enable/disable action and move it to config
- Don't store redirect_uri in StoredState