### PR TITLE
ci: add PAT_TOKEN to inputs

### DIFF
--- a/.github/workflows/on_schedule.yaml
+++ b/.github/workflows/on_schedule.yaml
@@ -6,6 +6,9 @@ jobs:
   update-charm-libs:
     name: Update Charm Libraries
     uses: ./.github/workflows/update_libs.yaml
+    secrets:
+      CHARMCRAFT_CREDENTIALS: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
 
   update-deps:
     name: Update Dependencies

--- a/.github/workflows/update_libs.yaml
+++ b/.github/workflows/update_libs.yaml
@@ -12,6 +12,8 @@ on:
     secrets:
       CHARMCRAFT_CREDENTIALS:
         required: true
+      PAT_TOKEN:
+        required: true
   workflow_dispatch:
     inputs:
       charmcraft_channel:


### PR DESCRIPTION
The action fails on workflow call due to no PAT_TOKEN supplied. This PR fixes it.