### PR TITLE
Add label config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -65,6 +65,10 @@ options:
       The provider's ID to be used in Kratos. The redirect_uri is generated based on this.
       You must not have 2 providers with the same ID registered in Kratos.
     type: string
+  label:
+    description: |
+      The text that will be shown to the user when asked to choose a provider, defaults to the provider type
+    type: string
   scope:
     description: Space separated list of allowed scopes for the provider.
     type: string

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,0 +1,7 @@
+# TODO: remove when new version is released
+# Relevant PR https://github.com/go-macaroon-bakery/py-macaroon-bakery/pull/95
+macaroonbakery==1.3.2
+pytest
+juju
+pytest-operator>=0.28.0
+-r requirements.txt

--- a/lib/charms/kratos_external_idp_integrator/v0/kratos_external_provider.py
+++ b/lib/charms/kratos_external_idp_integrator/v0/kratos_external_provider.py
@@ -129,7 +129,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 DEFAULT_RELATION_NAME = "kratos-external-idp"
 logger = logging.getLogger(__name__)
@@ -172,6 +172,7 @@ PROVIDER_PROVIDERS_JSON_SCHEMA = {
                     "scope": {"type": "string"},
                     "team_id": {"type": "string"},
                     "provider_id": {"type": "string"},
+                    "label": {"type": "string"},
                     "jsonnet_mapper": {"type": "string"},
                 },
                 "additionalProperties": True,
@@ -260,7 +261,7 @@ class BaseProviderConfigHandler:
     """The base class for parsing a provider's config."""
 
     mandatory_fields = {"provider", "client_id", "secret_backend", "scope"}
-    optional_fields = {"provider_id", "jsonnet_mapper"}
+    optional_fields = {"provider_id", "jsonnet_mapper", "label"}
     excluded_fields = {"enabled"}
     providers: List[str] = []
 
@@ -586,6 +587,7 @@ class Provider:
     provider: str
     relation_id: str
     scope: str = "profile email address phone"
+    label: Optional[str] = None
     client_secret: Optional[str] = None
     issuer_url: Optional[str] = None
     tenant_id: Optional[str] = None
@@ -619,6 +621,7 @@ class Provider:
             "id": self.provider_id,
             "client_id": self.client_id,
             "provider": self.provider,
+            "label": self.label or self.provider,
             "client_secret": self.client_secret,
             "issuer_url": self.issuer_url,
             "scope": self.scope.split(" "),

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -18,6 +18,7 @@ def config() -> Dict:
         "client_id": "client_id",
         "client_secret": "client_secret",
         "provider": "generic",
+        "label": "Some Provider",
         "issuer_url": "http://example.com",
         "secret_backend": "relation",
         "scope": "profile email address phone",
@@ -31,6 +32,7 @@ def generic_databag(config: Dict) -> Dict:
             {
                 "client_id": config["client_id"],
                 "provider": config["provider"],
+                "label": config["label"],
                 "secret_backend": config["secret_backend"],
                 "client_secret": config["client_secret"],
                 "issuer_url": config["issuer_url"],
@@ -60,6 +62,7 @@ def generic_kratos_config(config: Dict) -> Dict:
         "id": "generic_c1b858ba120b6a62d17865256fab2617b727ab27",
         "client_id": config["client_id"],
         "provider": config["provider"],
+        "label": config["label"],
         "client_secret": config["client_secret"],
         "issuer_url": config["issuer_url"],
         "scope": config["scope"].split(" "),

--- a/tox.ini
+++ b/tox.ini
@@ -69,10 +69,6 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    pytest-asyncio==0.21.1
-    pytest
-    juju
-    pytest-operator>=0.13.0
-    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/integration-requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
Add the `label` config option. The value of this config is used by the Login UI when generating the text of the button for authenticating with this provider. Right now the provider_id is used for generating this text.