### PR TITLE
Set default scopes for github

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -72,7 +72,6 @@ options:
   scope:
     description: Space separated list of allowed scopes for the provider.
     type: string
-    default: profile email address phone
   enabled:
     description: Controls whether the provider is enabled.
     type: boolean

--- a/lib/charms/kratos_external_idp_integrator/v0/kratos_external_provider.py
+++ b/lib/charms/kratos_external_idp_integrator/v0/kratos_external_provider.py
@@ -129,7 +129,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 DEFAULT_RELATION_NAME = "kratos-external-idp"
 logger = logging.getLogger(__name__)
@@ -260,9 +260,10 @@ def _validate_data(data: Dict, schema: Dict) -> None:
 class BaseProviderConfigHandler:
     """The base class for parsing a provider's config."""
 
-    mandatory_fields = {"provider", "client_id", "secret_backend", "scope"}
-    optional_fields = {"provider_id", "jsonnet_mapper", "label"}
+    mandatory_fields = {"provider", "client_id", "secret_backend"}
+    optional_fields = {"provider_id", "jsonnet_mapper", "label", "scope"}
     excluded_fields = {"enabled"}
+    default_scope = "profile email address phone"
     providers: List[str] = []
 
     @classmethod
@@ -308,7 +309,7 @@ class BaseProviderConfigHandler:
             "client_id": config["client_id"],
             "provider": config["provider"],
             "secret_backend": config["secret_backend"],
-            "scope": config["scope"],
+            "scope": config.get("scope", cls.default_scope),
         }
         ret.update({k: config[k] for k in cls.optional_fields if k in config})
         ret.update(cls._parse_provider_config(config))
@@ -341,7 +342,6 @@ class SocialConfigHandler(BaseProviderConfigHandler):
     providers = [
         "google",
         "facebook",
-        "github",
         "gitlab",
         "slack",
         "spotify",
@@ -383,6 +383,13 @@ class MicrosoftConfigHandler(SocialConfigHandler):
         }
 
 
+class GithubConfigHandler(SocialConfigHandler):
+    """The class for parsing a 'github' provider's config."""
+
+    default_scope = "user:email"
+    providers = ["github"]
+
+
 class AppleConfigHandler(BaseProviderConfigHandler):
     """The class for parsing an 'apple' provider's config."""
 
@@ -407,6 +414,7 @@ _config_handlers = [
     GenericConfigHandler,
     SocialConfigHandler,
     MicrosoftConfigHandler,
+    GithubConfigHandler,
     AppleConfigHandler,
 ]
 allowed_providers = {

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -81,6 +81,16 @@ def microsoft_config() -> Dict:
 
 
 @pytest.fixture
+def github_config() -> Dict:
+    return {
+        "client_id": "client_id",
+        "client_secret": "client_secret",
+        "provider": "github",
+        "secret_backend": "relation",
+    }
+
+
+@pytest.fixture
 def apple_config() -> Dict:
     return {
         "client_id": "client_id",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -166,6 +166,30 @@ def test_microsoft_invalid_config(harness: Harness, config: Dict, relation_data:
     assert app_data == {}
 
 
+def test_github_config(harness: Harness, github_config: Dict, relation_data: Dict) -> None:
+    expected_databag = {
+        "providers": [
+            {
+                "client_id": github_config["client_id"],
+                "provider": github_config["provider"],
+                "secret_backend": github_config["secret_backend"],
+                "client_secret": github_config["client_secret"],
+                "scope": "user:email",
+            }
+        ]
+    }
+
+    harness.update_config(github_config)
+    relation_id = harness.add_relation("kratos-external-idp", "kratos")
+    harness.add_relation_unit(relation_id, "kratos/0")
+    harness.update_relation_data(relation_id, "kratos", relation_data)
+
+    app_data = harness.get_relation_data(relation_id, harness.charm.app)
+
+    assert isinstance(harness.charm.unit.status, ActiveStatus)
+    assert parse_databag(app_data) == expected_databag
+
+
 def test_apple_config(harness: Harness, apple_config: Dict, relation_data: Dict) -> None:
     expected_databag = {
         "providers": [


### PR DESCRIPTION
IAM-617:

- When `provider_id` is `github` default to the `user:email` scope.

To test this you need to have a registered Github OAuth application to use for logging in.
To register a Github OAuth application:
1) Go to https://github.com/settings/applications/new. The application name and homepage URL do not matter, but the Authorization callback URL must be `https://<public-traefik-ip>/<model>-kratos/self-service/methods/oidc/callback/github` (you can always come back and change this after the bundle is deployed).
2) Generate a client secret

Now deploy the bundle, refresh with this charm and configure the kratos-external-idp-integrator:
```
charmcraft pack
juju deploy identity-platform --channel latest/edge --trust
juju refresh kratos-external-idp-integrator --path ./kratos-external-idp-integrator_ubuntu-22.04-amd64.charm
juju config kratos-external-idp-integrator \
    provider=github \
    client_id=<client-id> \
    client_secret=<client-secret> \
    provider_id=github
```
