### PR TITLE
chore: replace black with ruff as the formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,15 +9,23 @@ repos:
     - id: end-of-file-fixer
     - id: requirements-txt-fixer
     - id: trailing-whitespace
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.2.6
+  hooks:
+  - id: codespell
+    additional_dependencies:
+      - tomli
+- repo: https://github.com/pycqa/isort
+  rev: 5.13.2
+  hooks:
+    - id: isort
+      name: isort (python)
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.3.7
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
-- repo: https://github.com/psf/black
-  rev: 24.4.0
-  hooks:
-  - id: black
+    - id: ruff-format
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.9.0
   hooks:
@@ -25,6 +33,7 @@ repos:
       args: ["--config-file", "pyproject.toml"]
       additional_dependencies:
         - types-PyYAML
+        - types-jsonschema
 - repo: https://github.com/compilerla/conventional-pre-commit
   rev: v3.2.0
   hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ enhancements to this operator.
 ## Developing
 
 You can use the environments created by `tox` for development. It helps
-install `pre-commit` and `mypy` type checker.
+install `pre-commit`, `mypy` type checker, linting tools, and formatting tools.
 
 ```shell
 tox -e dev

--- a/fmt-requirements.txt
+++ b/fmt-requirements.txt
@@ -1,0 +1,2 @@
+isort
+ruff

--- a/lib/charms/kratos_external_idp_integrator/v0/kratos_external_provider.py
+++ b/lib/charms/kratos_external_idp_integrator/v0/kratos_external_provider.py
@@ -222,7 +222,7 @@ class DataValidationError(RuntimeError):
 def _load_data(data: Dict, schema: Dict) -> Dict:
     """Parses nested fields and checks whether `data` matches `schema`."""
     if "providers" not in data:
-        return dict(providers=[])
+        return {"providers": []}
 
     data = dict(data)
     try:
@@ -619,7 +619,7 @@ class Provider:
         return f"{self.provider}_{id}"
 
     @provider_id.setter
-    def provider_id(self, val) -> None:
+    def provider_id(self, val: str) -> None:
         self.id = val
 
     def config(self) -> Dict:
@@ -744,14 +744,9 @@ class ExternalIdpRequirer(Object):
         if not self._charm.unit.is_leader():
             return
 
-        data = dict(
-            providers=[
-                dict(
-                    redirect_uri=redirect_uri,
-                    provider_id=provider_id,
-                )
-            ]
-        )
+        data = {
+            "providers": [{"redirect_uri": redirect_uri, "provider_id": provider_id}],
+        }
 
         data = _dump_data(data, REQUIRER_JSON_SCHEMA)
 

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,0 +1,3 @@
+codespell
+isort
+ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,33 +12,59 @@ show_missing = true
 minversion = "6.0"
 log_cli_level = "INFO"
 
-# Formatting tools configuration
-[tool.black]
-line-length = 99
-target-version = ["py38"]
+# Linting and formatting tools configuration
+[tool.codespell]
+# https://github.com/codespell-project/codespell
+skip = ".git,.tox,build,lib,venv,.venv,.mypy_cache,icon.svg,__pycache__"
 
 [tool.isort]
+# Profiles: https://pycqa.github.io/isort/docs/configuration/profiles.html
 line_length = 99
 profile = "black"
 
-# Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
-max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore W503, E501 because using black creates errors with this
-# Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107"]
-# D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
-docstring-convention = "google"
-# Check for properly formatted copyright header in each file
-copyright-check = "True"
-copyright-author = "Canonical Ltd."
-copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
+[tool.ruff]
+# Default settings: https://docs.astral.sh/ruff/configuration/
+# Settings: https://docs.astral.sh/ruff/settings/
+line-length = 99
+include = ["pyproject.toml", "src/**/*.py", "tests/**/*.py", "lib/charms/kratos_external_idp_integrator/**/*.py"]
+extend-exclude = ["__pycache__", "*.egg_info"]
+target-version = "py38"
+preview = true
 
+[tool.ruff.lint]
+# Rules: https://docs.astral.sh/ruff/rules/
+select = ["E", "W", "F", "C", "N", "D", "CPY"]
+ignore = [
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D105",
+    "D107",
+    "D203",
+    "D204",
+    "D213",
+    "D215",
+    "D400",
+    "D404",
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D413",
+    "E501",
+    "N818"
+]
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
+
+[tool.ruff.lint.flake8-copyright]
+author = "Canonical Ltd."
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
 
 [tool.mypy]
 pretty = true

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -45,14 +45,12 @@ def generic_databag(config: Dict) -> Dict:
 @pytest.fixture
 def relation_data() -> Dict:
     return {
-        "providers": json.dumps(
-            [
-                {
-                    "redirect_uri": "https://example.com/callback",
-                    "provider_id": "provider",
-                }
-            ]
-        )
+        "providers": json.dumps([
+            {
+                "redirect_uri": "https://example.com/callback",
+                "provider_id": "provider",
+            }
+        ])
     }
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -28,40 +28,30 @@ deps =
     pre-commit
     mypy
     types-PyYAML
+    types-jsonschema
+    -r{toxinidir}/fmt-requirements.txt
+    -r{toxinidir}/lint-requirements.txt
 commands =
     pre-commit install -t commit-msg
 
 [testenv:fmt]
-description = Apply coding style standards to code
+description = Apply coding style standards
 deps =
-    black
-    isort
+    -r{toxinidir}/fmt-requirements.txt
 commands =
     isort {[vars]all_path}
-    black {[vars]all_path}
+    ruff format {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
-    black
-    flake8==5.0.4
-    flake8-docstrings
-    flake8-copyright
-    flake8-builtins
-    pyproject-flake8
-    pep8-naming
-    isort
-    codespell
+    ; The tomli package is needed because https://github.com/codespell-project/codespell?tab=readme-ov-file#using-a-config-file
+    tomli
+    -r{toxinidir}/lint-requirements.txt
 commands =
-    # uncomment the following line if this charm owns a lib
-    codespell {[vars]lib_path}
-    codespell {toxinidir} --skip {toxinidir}/.git --skip {toxinidir}/.tox \
-      --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
-      --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
-    # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path}
+    codespell {toxinidir}/
     isort --check-only --diff {[vars]all_path}
-    black --check --diff {[vars]all_path}
+    ruff check --show-fixes {[vars]all_path}
 
 [testenv:unit]
 description = Run unit tests


### PR DESCRIPTION
This pull request:

- replaces black with ruff as the formatter
- fixes the lint and format issues with ruff
- keeps the isort to keep the original behaviors for import sorting
- puts the codespell configuration to the pyproject.toml file to be consistent with other tools