### PR TITLE
chore: switch to platforms in charmcraft.yaml

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -98,9 +98,8 @@ actions:
   get-redirect-uri:
     description: Get the Kratos' client redirect_uri
 
-base: ubuntu@22.04
 platforms:
-  amd64:
+  ubuntu@22.04:amd64:
 
 parts:
   charm:


### PR DESCRIPTION
This PR changes the charm's charmcraft `base` to `platforms`. This is a prerequisite to add main branch to charmcraftcache builds and switch to reusable workflows.