### PR TITLE
chore: make the lib version consecutive because last update was not s…

### DIFF
--- a/lib/charms/kratos_external_idp_integrator/v0/kratos_external_provider.py
+++ b/lib/charms/kratos_external_idp_integrator/v0/kratos_external_provider.py
@@ -127,7 +127,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 12
 
 PYDEPS = ["jsonschema"]
 


### PR DESCRIPTION
Have to mark the library patch version back to `12` because the last update was not successfully released. Charmcraft is not happy about that.